### PR TITLE
Remove console io

### DIFF
--- a/pry-coolline.gemspec
+++ b/pry-coolline.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<coolline>, ["~> 0.2.0"])
+      s.add_runtime_dependency(%q<coolline>, ["~> 0.4.0"])
     else
-      s.add_dependency(%q<coolline>, ["~> 0.2.0"])
+      s.add_dependency(%q<coolline>, ["~> 0.4.0"])
     end
   else
-    s.add_dependency(%q<coolline>, ["~> 0.2.0"])
+    s.add_dependency(%q<coolline>, ["~> 0.4.0"])
   end
 end


### PR DESCRIPTION
`io/console` is part of Ruby and coolline itself works without the gem. As
it turns out, this gem dependency is actually unnecessary and is
preventing pry-coolline from building under Ruby 2.0 (as the io-console
gem has native extensions that fail to configure). Remove the gem
dependency and instead use the `io/console` that already ships with Ruby
1.9.x to also support Ruby 2.0.0

Additionally, update the dependency on coolline to `~> 0.4.0`
