### PR TITLE
Make pry-coolline.gemspec a valid gemspec

### DIFF
--- a/pry-coolline.gemspec
+++ b/pry-coolline.gemspec
@@ -9,13 +9,13 @@ Gem::Specification.new do |s|
   s.date = "2012-04-03"
   s.description = "Live syntax-highlighting for the Pry REPL"
   s.email = "jrmair@gmail.com"
-  s.files = [".gemtest", ".gitignore", ".yardopts", "CHANGELOG", "LICENSE", "README.md", "Rakefile", "lib/pry-coolline.rb", "lib/pry-coolline/version.rb", "pry-coolline.gemspec", "test/test.rb"]
+  s.files = [".gemtest", ".gitignore", ".yardopts", "CHANGELOG", "LICENSE", "README.md", "Rakefile", "lib/pry-coolline.rb", "lib/pry-coolline/version.rb", "pry-coolline.gemspec"]
   s.homepage = "https://github.com/pry/pry-coolline"
   s.require_paths = ["lib"]
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.2")
   s.rubygems_version = "1.8.16"
   s.summary = "Live syntax-highlighting for the Pry REPL"
-  s.test_files = ["test/test.rb"]
+  s.test_files = Dir["test/**/*.rb"]
 
   if s.respond_to? :specification_version then
     s.specification_version = 3


### PR DESCRIPTION
The `test/test.rb` file no longer exists and was replaced long ago.
Building the gem locally throws warnings about the gemspec being valid
for that reason. The test files probably don't need to be included in
s.files, but s.test_files should include the real test files.

Signed-off-by: David Celis me@davidcel.is
