### PR TITLE
Removed io-console gem dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,6 @@ def apply_spec_defaults(s)
   s.email = 'jrmair@gmail.com'
   s.description = s.summary
   s.add_dependency("coolline","~>0.3")
-  s.add_dependency("io-console","~>0.3.0")
   s.add_development_dependency("riot")
   s.required_ruby_version = '>= 1.9.2'
   s.require_path = 'lib'


### PR DESCRIPTION
Removed io-console from dependencies in an optimistic attempt to make it install on Ruby 2.0.
