### PR TITLE
Enabled the option to actually disable paren matching

### DIFF
--- a/lib/pry-coolline.rb
+++ b/lib/pry-coolline.rb
@@ -4,7 +4,9 @@
 require 'pry'
 require 'pry-coolline/version'
 
-Pry.config.coolline_paren_matching ||= true
+unless defined?(Pry.config.coolline_paren_matching)
+  Pry.config.coolline_paren_matching = true
+end
 
 Pry.config.coolline_matched_paren    ||= "\e[42m"
 Pry.config.coolline_mismatched_paren ||= "\e[41m"


### PR DESCRIPTION
The semantics of the `||=` operator prevented the user from being able to set
`Pry.config.coolline_paren_matching = false` and have it mean anything.
Instead, ensure the parameter hasn't been defined at all before setting it.
