### PR TITLE
Support latest Pry::BondCompleter rename start -> setup

### DIFF
--- a/lib/pry-coolline.rb
+++ b/lib/pry-coolline.rb
@@ -21,7 +21,11 @@ begin
 
   require 'pry-bond'
 
-  Pry::BondCompleter.start
+  if Pry::BondCompleter.respond_to?(:start)
+    Pry::BondCompleter.start
+  elsif Pry::BondCompleter.respond_to?(:setup)
+    Pry::BondCompleter.setup
+  end
   # Fixes a bug with certain gem releases of pry
   Pry.config.completer = Pry::BondCompleter
 

--- a/lib/pry-coolline.rb
+++ b/lib/pry-coolline.rb
@@ -2,7 +2,6 @@
 # (C) John Mair (banisterfiend); MIT license
 
 require 'pry'
-require 'pry-coolline/version'
 
 unless defined?(Pry.config.coolline_paren_matching)
   Pry.config.coolline_paren_matching = true

--- a/pry-coolline.gemspec
+++ b/pry-coolline.gemspec
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
-$LOAD_PATH.unshift File.expand_path(File.join("../lib", __FILE__))
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'pry-coolline/version'
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
Doesn't work with latest