### PR TITLE
Support v0.13 Pry config API, fixes #36

### DIFF
--- a/lib/pry-coolline/wrapper.rb
+++ b/lib/pry-coolline/wrapper.rb
@@ -31,8 +31,15 @@ module PryCoolline
       cool.word_boundaries = cool.completion_word_boundaries +
         [".", ":"]
 
+      pry_history_file =
+        if Gem::Version.new(Pry::VERSION) >= Gem::Version.new("0.13")
+          Pry.config.history_file
+        else
+          Pry.config.history.file
+        end
+
       # bring saved history into coolline
-      cool.history_file = File.expand_path(Pry.config.history.file)
+      cool.history_file = File.expand_path(pry_history_file)
 
       cool.transform_proc = proc do
         if Pry.color


### PR DESCRIPTION
`Pry.config.history.file` no longer exists as of:

https://github.com/pry/pry/commit/e5556a2be8627ec3fe594c738f10422d5a1f5d43

and is now `Pry.config.history_file`