### PR TITLE
change how load path is modified

### DIFF
--- a/pry-coolline.gemspec
+++ b/pry-coolline.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 
-$LOAD_PATH.unshift File.expand_path(File.join("../lib", __FILE__))
+$:.push File.expand_path('../lib', __FILE__)
 require 'pry-coolline/version'
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
The require on line 4 breaks under ruby 2.7.4 and the gem can't install.